### PR TITLE
"Hot fix" for ESP82XX

### DIFF
--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -41,13 +41,18 @@ void StreamServerComponent::setup() {
 
     this->socket_ = socket::socket(AF_INET, SOCK_STREAM, PF_INET);
 	
-    struct timeval timeout;      
+    struct timeval timeout;
     timeout.tv_sec = 0;
     timeout.tv_usec = 20000; // ESPHome recommends 20-30 ms max for timeouts
-    
+
+    // For ESP-32
     this->socket_->setsockopt(SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout, sizeof(timeout));
     this->socket_->setsockopt(SOL_SOCKET, SO_RCVTIMEO, (char *)&timeout, sizeof(timeout));
-  
+    // 
+    // For ESP82XX
+    // this->socket_->setsockopt(SOL_SOCKET, LWIP_SO_RCVTIMEO, (char *)&timeout, sizeof(timeout));
+    // this->socket_->setsockopt(SOL_SOCKET, LWIP_SO_RCVTIMEO, (char *)&timeout, sizeof(timeout));
+
     this->socket_->bind(reinterpret_cast<struct sockaddr *>(&bind_addr), sizeof(struct sockaddr_in));
     this->socket_->listen(8);
 


### PR DESCRIPTION
Adding patch for ESP8XX so its possible compiling the firmware. I do not have the knowledge off writing C++ so i have adding it as comment and the user must comment the ESP32 out and un-commented lines fro ESP82XX for changing arch. Im very sure some one can doing it automatic detecting if ESP 32 or 82XX and dont need my hack.

Looks working OK on my test setup with one "IKEA Marcus2 EZSP 6.10.3.0 one one D1 Mini clone.

PS: Some extra spaces is taken away.