### PR TITLE
AsyncTCP

### DIFF
--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -19,17 +19,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/socket/socket.h"
 #include "esphome/components/uart/uart.h"
-
-#ifdef ARDUINO_ARCH_ESP8266
-#include <ESPAsyncTCP.h>
-#else
-// AsyncTCP.h includes parts of freertos, which require FreeRTOS.h header to be included first
-#include <freertos/FreeRTOS.h>
-#include <AsyncTCP.h>
-#endif
-
-
-
+#include "esphome/components/async_tcp/"
 
 #include <memory>
 #include <string>

--- a/components/stream_server/stream_server.h
+++ b/components/stream_server/stream_server.h
@@ -19,7 +19,6 @@
 #include "esphome/core/component.h"
 #include "esphome/components/socket/socket.h"
 #include "esphome/components/uart/uart.h"
-#include "esphome/components/async_tcp/"
 
 #include <memory>
 #include <string>


### PR DESCRIPTION
Looks like esphome updated/included AsyncTCP in in april (https://github.com/esphome/esphome/pull/4764), which now includes the logic regarding library for ESP8266/ESP32. So this PR removes the AsyncTCP include, as it seems to be part of esphome core now: https://github.com/esphome/esphome/blob/dev/esphome/components/async_tcp/__init__.py