### PR TITLE
Fixed build for esphome 2024.3.0

### DIFF
--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -108,9 +108,13 @@ void StreamServerComponent::write() {
 
 void StreamServerComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "Stream Server:");
-    ESP_LOGCONFIG(TAG, "  Address: %s:%u",
-                  esphome::network::get_ip_address().str().c_str(),
-                  this->port_);
+    std::string ip_str = "";
+    for (auto &ip : network::get_ip_addresses()) {
+      if (ip.is_set())
+        ip_str += " " + ip.str();
+    }
+    ESP_LOGCONFIG(TAG, "  Address:%s", ip_str.c_str());
+    ESP_LOGCONFIG(TAG, "  Port: %u", this->port_);
 }
 
 void StreamServerComponent::on_shutdown() {


### PR DESCRIPTION
To fix the build in last ESPHome released (2024.3.0), changed a way how IP and port printed