### PR TITLE
sin_zero initializer

### DIFF
--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -36,7 +36,8 @@ void StreamServerComponent::setup() {
         .sin_port = htons(this->port_),
         .sin_addr = {
             .s_addr = ESPHOME_INADDR_ANY,
-        }
+        },
+        .sin_zero = {0}
     };
 
     this->socket_ = socket::socket(AF_INET, SOCK_STREAM, PF_INET);


### PR DESCRIPTION
Fix compilation warning:

```
src/esphome/components/stream_server/stream_server.cpp: In member function 'virtual void StreamServerComponent::setup()':
src/esphome/components/stream_server/stream_server.cpp:40:5: warning: missing initializer for member 'sockaddr_in::sin_zero' [-Wmissing-field-initializers]
```
