### PR TITLE
fix compatibility with esphome 2026.1.0

### DIFF
--- a/components/stream_server/stream_server.cpp
+++ b/components/stream_server/stream_server.cpp
@@ -69,7 +69,7 @@ void StreamServerComponent::accept() {
         return;
 
     socket->setblocking(false);
-    std::string identifier = socket->getpeername();
+    std::string identifier = inet_ntoa(client_addr.sin_addr);
     this->clients_.emplace_back(std::move(socket), identifier);
     ESP_LOGD(TAG, "New client connected from %s", identifier.c_str());
 }


### PR DESCRIPTION
```shell
$ esphome --version
Version: 2026.1.0-dev
```

```make
...
Compiling .pioenvs/hallzigbee/src/esphome/core/component.cpp.o
src/esphome/components/stream_server/stream_server.cpp: In member function 'void StreamServerComponent::accept()':
src/esphome/components/stream_server/stream_server.cpp:72:49: error: no matching function for call to 'esphome::socket::Socket::getpeername()'
   72 |     std::string identifier = socket->getpeername();
      |                              ~~~~~~~~~~~~~~~~~~~^~
In file included from src/esphome/components/stream_server/stream_server.h:20,
                 from src/esphome/components/stream_server/stream_server.cpp:17:
src/esphome/components/socket/socket.h:43:15: note: candidate: 'virtual int esphome::socket::Socket::getpeername(sockaddr*, socklen_t*)'
   43 |   virtual int getpeername(struct sockaddr *addr, socklen_t *addrlen) = 0;
      |               ^~~~~~~~~~~
src/esphome/components/socket/socket.h:43:15: note:   candidate expects 2 arguments, 0 provided
*** [.pioenvs/hallzigbee/src/esphome/components/stream_server/stream_server.cpp.o] Error 1
```

the `accept()` function already receives the client address via the `accept()` call itself; `client_addr` is populated with the peer's address information. hence, calling `getpeername()` is redundant.