### PR TITLE
fix: remove nonexistent uart.request_wake_loop_on_rx() call

### DIFF
--- a/components/stream_server/__init__.py
+++ b/components/stream_server/__init__.py
@@ -48,5 +48,3 @@ def to_code(config):
 	yield cg.register_component(var, config)
 	yield uart.register_uart_device(var, config)
 
-	# Request UART to wake the main loop when data arrives for low-latency processing
-	uart.request_wake_loop_on_rx()


### PR DESCRIPTION
`uart.request_wake_loop_on_rx()` does not exist in esphome.components.uart and causes an AttributeError on ESPHome 2026.3.0+ causing:

`AttributeError: module esphome.components.uart' has no attribute request_wake_loop_on_rx'`